### PR TITLE
Make description field optional in Item and Platform types; condition…

### DIFF
--- a/src/components/categoryCardsGrid/CategoryCardsGrid.tsx
+++ b/src/components/categoryCardsGrid/CategoryCardsGrid.tsx
@@ -19,7 +19,7 @@ interface Item {
     type: "image" | "component"
     title: string
     followers: string
-    description: string
+    description?: string
     color?: string
     link: string
     img?: string
@@ -79,18 +79,20 @@ export default function CategoryCardsGrid({
                                         </h4>
 
                                         {/* Followers + View details */}
-                                        <div className='flex justify-between items-center text-sm mt-1'>
-                                            <span className='text-gray-600'>
-                                                {p.followers}
-                                            </span>
+                                        {p.description && (
+                                            <div className="flex justify-between items-center text-sm mt-1">
+                                                <span className="text-gray-600">
+                                                    {p.followers}
+                                                </span>
 
-                                            <button
-                                                onClick={() => setActiveItem(p)}
-                                                className='text-primary underline font-medium'
-                                            >
-                                                View details
-                                            </button>
-                                        </div>
+                                                <button
+                                                    onClick={() => setActiveItem(p)}
+                                                    className="text-primary underline font-medium"
+                                                >
+                                                    View details
+                                                </button>
+                                            </div>
+                                        )}
 
                                         {/* Pricing */}
                                         <div className='mt-2'>

--- a/src/components/platforms/platformsData.tsx
+++ b/src/components/platforms/platformsData.tsx
@@ -37,6 +37,17 @@ export const categories: PlatformCategory[] = [
                         height: 180,
                     },
                 ],
+            },
+            {
+                id: 2,
+                type: "component",
+                img: "/images/course_banner/corporate.png",
+                icon: <FaUsers className='text-red-600 text-4xl' />,
+                title: "Corporate Coaching + 1:1 Mentorship",
+                followers: "20+ Members",
+                link: "https://collegetocorporate.akamai.net.in/new-courses/2-working-professionals-career-guide",      
+                color: "from-red-50 to-red-100",
+
             }
         ],
     },

--- a/src/components/platforms/types.ts
+++ b/src/components/platforms/types.ts
@@ -15,7 +15,7 @@ type Platform = {
   icon?: JSX.Element;
   title: string;
   followers: string;
-  description: string;
+  description?: string;
   link: string;
   color: string;
   testimonials?: ITestimonial[]


### PR DESCRIPTION
This pull request introduces improvements to the handling of optional descriptions for category and platform items, and adds a new "Corporate Coaching + 1:1 Mentorship" card to the platforms data. The changes enhance flexibility for displaying items without descriptions and expand the available categories.

**Type and UI updates for optional descriptions:**

* Made the `description` property optional in both the `Item` interface (`CategoryCardsGrid.tsx`) and the `Platform` type (`types.ts`), allowing items to omit descriptions if not needed. [[1]](diffhunk://#diff-905c22c070ba1e68f67c9f3edca2ad43431db40e3cb702a0319a92ea4cb1f046L22-R22) [[2]](diffhunk://#diff-5813e7b0a8ed84ec291d69767ac5b58a61d5097d209326b7ab0ee22e0dde7a7eL18-R18)
* Updated the `CategoryCardsGrid` component to only render the followers and "View details" section if a description is present, preventing empty UI elements for items without descriptions.

**Data expansion:**

* Added a new category card for "Corporate Coaching + 1:1 Mentorship" to the `categories` array in `platformsData.tsx`, including its icon, image, color, followers, and link.