### PR TITLE
Add Cohort Pricing Section and Frontend Interview Banner components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,8 @@ import ContactMe from "@/components/contactMe/ContactMe"
 // import BrandPartners from "@/components/brandPartners/BrandPartners"
 import CollegeVisits from "@/components/collegeVisits/CollegeVisits"
 import Certifications from "@/components/certifications/Certifications"
+// import FrontendInterviewBanner from "@/components/heroBanner/FrontendInterviewBanner"
+// import CohortPricingSection from "@/components/cohortpricing/CohortPricingSection"
 
 export default function Home() {
     const [showPromo, setShowPromo] = useState(false)
@@ -132,6 +134,8 @@ export default function Home() {
 
             {/* Main content */}
             <HeroBanner />
+            {/* <FrontendInterviewBanner />
+            <CohortPricingSection/> */}
             <div className='flex-1 pl-6 pr-6 pb-6'>
                 <header className='text-center pt-6 px-6 pb-4'>
                 <motion.h1

--- a/src/components/cohortpricing/CohortPricingSection.tsx
+++ b/src/components/cohortpricing/CohortPricingSection.tsx
@@ -1,0 +1,32 @@
+import PricingCard from "./PricingCard";
+import { pricingPlans } from "./cohortData";
+
+export default function CohortPricingSection() {
+  return (
+    <section className="bg-white px-6 py-20 text-slate-900">
+      <div className="mx-auto max-w-6xl">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="text-4xl font-extrabold md:text-5xl">
+            Can't Wait for Cohort 3? Start Preparing Now
+          </h2>
+
+          <p className="mt-8 text-lg leading-8 text-slate-500">
+            Cohort 2 is live and delivering results. While you wait for Cohort
+            3, get a head start with our self-paced prep kit or accelerate your
+            journey with dedicated 1-on-1 mentorship.
+          </p>
+        </div>
+
+        <div className="mt-14 grid gap-10 lg:grid-cols-3">
+          {pricingPlans.map((plan) => (
+            <PricingCard key={plan.id} plan={plan} />
+          ))}
+        </div>
+
+        <p className="mt-12 text-center text-lg font-bold text-slate-500">
+          Choose what works best for your learning style and schedule
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/cohortpricing/PricingCard.tsx
+++ b/src/components/cohortpricing/PricingCard.tsx
@@ -1,0 +1,84 @@
+import { PricingPlan } from "./types";
+
+interface PricingCardProps {
+  plan: PricingPlan;
+}
+
+export default function PricingCard({ plan }: PricingCardProps) {
+  return (
+    <div
+      className={
+        plan.featured
+          ? "group relative flex min-h-[640px] flex-col overflow-hidden rounded-2xl bg-gradient-to-b from-[#6366f1] to-[#7c3aed] px-9 py-12 text-center text-white shadow-xl transition-all duration-500 ease-out hover:-translate-y-4 hover:scale-[1.02] hover:shadow-[0_25px_60px_rgba(99,102,241,0.45)]"
+          : "group relative flex min-h-[640px] flex-col overflow-hidden rounded-2xl border-2 border-[#6d5dfc] bg-[#f4f0ff] px-9 py-12 text-center shadow-lg transition-all duration-500 ease-out hover:-translate-y-3 hover:scale-[1.015] hover:border-[#5b4ff7] hover:shadow-[0_20px_50px_rgba(109,93,252,0.25)]"
+      }
+    >
+      <div className="pointer-events-none absolute inset-0 rounded-2xl bg-gradient-to-br from-white/20 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+
+      {plan.featured && (
+        <div className="relative z-10 mb-6">
+          <span className="rounded-full bg-white/20 px-4 py-2 text-xs font-bold uppercase tracking-wider backdrop-blur">
+            Most Popular
+          </span>
+        </div>
+      )}
+
+      <div className="relative z-10 text-5xl transition-transform duration-500 group-hover:-rotate-6 group-hover:scale-125">
+        {plan.icon}
+      </div>
+
+      <h3 className="relative z-10 mt-10 text-3xl font-extrabold leading-snug transition-all duration-300 group-hover:tracking-wide">
+        {plan.title}
+      </h3>
+
+      <p
+        className={
+          plan.featured
+            ? "relative z-10 mt-7 text-base leading-7 text-white/90"
+            : "relative z-10 mt-7 text-base leading-7 text-slate-500"
+        }
+      >
+        {plan.description}
+      </p>
+
+      <ul
+        className={
+          plan.featured
+            ? "relative z-10 mx-auto mt-14 space-y-4 text-left text-sm text-white"
+            : "relative z-10 mx-auto mt-14 space-y-4 text-left text-sm text-slate-700"
+        }
+      >
+        {plan.features.map((feature) => (
+          <li
+            key={feature}
+            className="transition-all duration-300 hover:translate-x-2"
+          >
+            ✓ {feature}
+          </li>
+        ))}
+      </ul>
+
+      <div className="relative z-10 mt-auto pt-14">
+        <div
+          className={
+            plan.featured
+              ? "text-4xl font-extrabold"
+              : "text-4xl font-extrabold text-[#6d5dfc]"
+          }
+        >
+          {plan.price}
+        </div>
+
+        <button
+          className={
+            plan.featured
+              ? "mt-8 rounded-lg bg-white px-10 py-4 font-extrabold text-[#6366f1] transition-all duration-300 hover:-translate-y-1 hover:scale-105 hover:shadow-xl active:scale-95"
+              : "mt-8 rounded-lg bg-[#6d5dfc] px-10 py-4 font-extrabold text-white transition-all duration-300 hover:-translate-y-1 hover:scale-105 hover:bg-[#5b4ff7] hover:shadow-xl active:scale-95"
+          }
+        >
+          {plan.buttonText}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/cohortpricing/cohortData.ts
+++ b/src/components/cohortpricing/cohortData.ts
@@ -1,0 +1,50 @@
+import { PricingPlan } from "./types";
+
+export const pricingPlans: PricingPlan[] = [
+    {
+        id: "prep-kit",
+        icon: "📚",
+        title: "Frontend Interview Prep Kit",
+        description:
+            "The same material used by Cohort 1 & 2 participants — now available for self-paced learning with bi-weekly AMA sessions",
+        features: [
+            "16 Recorded Sessions",
+            "Notion Study Materials",
+            "Bi-Weekly AMA Sessions",
+            "Lifetime Access",
+        ],
+        price: "₹4,999",
+        buttonText: "Get the Prep Kit",
+        featured: true,
+    },
+    {
+        id: "mentorship",
+        icon: "👥",
+        title: "1-on-1 Mentorship",
+        description:
+            "Don't want to wait? Get personalized mentorship with weekly sessions, mock interviews, and hands-on guidance",
+        features: [
+            "Dedicated Staff Engineer Mentor",
+            "Weekly 1-on-1 Sessions",
+            "Mock Interviews & Feedback",
+            "Resume & Profile Review",
+        ],
+        price: "₹15,000/month",
+        buttonText: "Start Mentorship",
+    },
+    {
+        id: "cohort",
+        icon: "🚀",
+        title: "Intensive Cohort",
+        description:
+            "Cohort 2 is live now! Join the waitlist for Cohort 3 — 8 weeks of live sessions, group learning, and placement support",
+        features: [
+            "8 Weeks Intensive",
+            "Live Sessions + Recording",
+            "1-on-1 Mentoring",
+            "Placement Support",
+        ],
+        price: "Cohort 3: Oct 2026",
+        buttonText: "Join Waitlist",
+    },
+];

--- a/src/components/cohortpricing/index.ts
+++ b/src/components/cohortpricing/index.ts
@@ -1,0 +1,1 @@
+export { default as CohortPricingSection } from "./CohortPricingSection";

--- a/src/components/cohortpricing/types.ts
+++ b/src/components/cohortpricing/types.ts
@@ -1,0 +1,10 @@
+export interface PricingPlan {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  features: string[];
+  price: string;
+  buttonText: string;
+  featured?: boolean;
+}

--- a/src/components/heroBanner/FrontendInterviewBanner.tsx
+++ b/src/components/heroBanner/FrontendInterviewBanner.tsx
@@ -1,0 +1,152 @@
+import { frontendInterviewBannerData } from "./frontendInterviewBannerData";
+
+export default function FrontendInterviewBanner() {
+  const data = frontendInterviewBannerData;
+
+  return (
+    <section className="relative min-h-screen overflow-hidden bg-gradient-to-br from-[#6366f1] via-[#755cf2] to-[#8657f2] text-white">
+      <div className="mx-auto flex min-h-screen max-w-6xl items-center px-6 py-12">
+        <div className="grid w-full grid-cols-1 items-start gap-14 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="text-center lg:text-left">
+            <div className="mb-8 inline-flex max-w-xl items-center rounded-lg border border-cyan-200 bg-white px-5 py-4 text-sm font-semibold text-slate-800 shadow-sm">
+              <span className="mr-2 h-3 w-3 shrink-0 rounded-full bg-emerald-400 shadow-[0_0_12px_rgba(52,211,153,0.8)]" />
+              <span>{data.badge}</span>
+            </div>
+
+            <h1 className="mx-auto max-w-xl text-center text-5xl font-extrabold leading-tight tracking-tight md:text-6xl lg:mx-0">
+              {data.title} <br />
+              {data.titleHighlight}
+            </h1>
+
+            <p className="mx-auto mt-6 max-w-xl text-center text-lg leading-8 text-white/85 lg:mx-0">
+              {data.description}
+            </p>
+
+            <div className="mx-auto mt-8 max-w-xl rounded-md bg-indigo-500/35 px-5 py-4 text-center text-sm font-bold shadow-sm backdrop-blur lg:mx-0">
+              {data.liveNotice}
+            </div>
+
+            <div className="mt-10 flex justify-center gap-4 lg:justify-start">
+              {data.logos.map((logo) => (
+                <LogoCard key={logo.id} label={logo.label} dark={logo.dark} />
+              ))}
+            </div>
+
+            <div className="mx-auto mt-8 max-w-xl space-y-4 lg:mx-0">
+              <button className="w-full rounded-xl bg-white px-6 py-5 text-base font-extrabold text-indigo-600 shadow-lg transition hover:-translate-y-0.5 hover:shadow-xl">
+                {data.buttons.prepKit}
+              </button>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <button className="rounded-xl border-2 border-white/80 px-6 py-5 text-base font-extrabold text-white transition hover:bg-white/10">
+                  {data.buttons.mentorship}
+                </button>
+
+                <button className="rounded-xl bg-emerald-500 px-6 py-5 text-base font-extrabold text-white shadow-lg transition hover:bg-emerald-600">
+                  {data.buttons.waitlist}
+                </button>
+              </div>
+            </div>
+
+            <div className="mx-auto mt-8 max-w-xl rounded-2xl border border-white/25 bg-white/10 p-6 text-left backdrop-blur lg:mx-0">
+              <div className="flex gap-5">
+                <div className="text-4xl">{data.questionBox.icon}</div>
+
+                <div>
+                  <h3 className="font-extrabold">{data.questionBox.title}</h3>
+
+                  <p className="mt-2 text-sm leading-6 text-white/80">
+                    {data.questionBox.description}
+                  </p>
+
+                  <button className="mt-5 rounded-lg bg-green-500 px-6 py-3 font-bold text-white transition hover:bg-green-600">
+                    {data.questionBox.buttonText}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center lg:pt-2">
+            <div className="rounded-3xl bg-white/20 p-2 shadow-2xl backdrop-blur-md">
+              <img
+                src={data.mentor.image}
+                alt={data.mentor.name}
+                className="h-[340px] w-[260px] rounded-2xl object-cover"
+              />
+            </div>
+
+            <h2 className="mt-6 text-center text-3xl font-extrabold text-white drop-shadow-lg">
+              {data.mentor.name}
+            </h2>
+
+            <p className="mt-2 text-center text-white/80">
+              {data.mentor.role}
+            </p>
+
+            <div className="mt-8 grid w-full max-w-md grid-cols-3 gap-4">
+              {data.stats.map((stat) => (
+                <InfoCard
+                  key={stat.id}
+                  icon={stat.icon}
+                  title={stat.title}
+                  value={stat.value}
+                />
+              ))}
+            </div>
+
+            <div className="mt-8 w-full max-w-md rounded-2xl border border-white/25 bg-white/10 p-6 text-center backdrop-blur">
+              <h3 className="text-xl font-extrabold">
+                {data.mentorship.title}
+              </h3>
+
+              <p className="mt-3 text-sm leading-6 text-white/80">
+                {data.mentorship.description}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function LogoCard({
+  label,
+  dark = false,
+}: {
+  label: string;
+  dark?: boolean;
+}) {
+  return (
+    <div className="flex h-16 w-16 items-center justify-center rounded-lg bg-white text-sm font-extrabold text-slate-900 shadow-md">
+      <span
+        className={
+          dark
+            ? "rounded bg-black px-2 py-1 text-[9px] text-white"
+            : "text-2xl text-indigo-600"
+        }
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function InfoCard({
+  icon,
+  title,
+  value,
+}: {
+  icon: string;
+  title: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-xl border border-white/30 bg-white/10 p-4 text-center backdrop-blur">
+      <div className="text-2xl">{icon}</div>
+      <p className="mt-2 text-xs text-white/70">{title}</p>
+      <p className="mt-2 text-sm font-extrabold sm:text-base">{value}</p>
+    </div>
+  );
+}

--- a/src/components/heroBanner/frontendInterviewBannerData.ts
+++ b/src/components/heroBanner/frontendInterviewBannerData.ts
@@ -1,0 +1,76 @@
+export const frontendInterviewBannerData = {
+  badge:
+    "Cohort 2 Live Now • 70% Placement Rate • 1-on-1 Mentorship & Prep Kit Available",
+
+  title: "Master Frontend",
+  titleHighlight: "Interviews in 8 Weeks",
+
+  description:
+    "Learn from a Staff Engineer at IBM. Intensive mentorship, live sessions, mock interviews, and placement support. Cohort 3 tentative start: October 1st week, 2026.",
+
+  liveNotice:
+    "🎉 Cohort 2 is Live! • Start with Prep Kit or 1-on-1 Mentorship today",
+
+  logos: [
+    {
+      id: "microsoft",
+      label: "▦",
+    },
+    {
+      id: "uber",
+      label: "Uber",
+      dark: true,
+    },
+    {
+      id: "atlassian",
+      label: "A",
+    },
+  ],
+
+  buttons: {
+    prepKit: "📚 Get Interview Prep Kit - ₹4,999",
+    mentorship: "👥 1-on-1 Mentorship",
+    waitlist: "📋 Join Waitlist for Cohort 3",
+  },
+
+  questionBox: {
+    icon: "☁️",
+    title: "Have Questions?",
+    description:
+      "Reach out directly on WhatsApp at +91 9XXXXXXXX — we're happy to help with anything",
+    buttonText: "Message on WhatsApp",
+  },
+
+  mentor: {
+    image: "/images/creators/manohar_batra.png",
+    name: "Manohar Batra",
+    role: "Staff Engineer @ IBM",
+  },
+
+  stats: [
+    {
+      id: "status",
+      icon: "🔴",
+      title: "Status",
+      value: "Live",
+    },
+    {
+      id: "cohort",
+      icon: "📅",
+      title: "Cohort",
+      value: "Oct 2026",
+    },
+    {
+      id: "salary",
+      icon: "💰",
+      title: "Salary",
+      value: "₹25-45 LPA",
+    },
+  ],
+
+  mentorship: {
+    title: "Mentorship Includes",
+    description:
+      "Live frontend sessions, mock interviews, resume review, project guidance, and placement-focused preparation.",
+  },
+};


### PR DESCRIPTION
This pull request introduces two new major UI components—`FrontendInterviewBanner` and `CohortPricingSection`—for the homepage, along with supporting data and types. These components are currently imported but commented out in `page.tsx`. The changes modularize pricing and promotional content, making it easier to manage and update offerings for frontend interview preparation and mentorship.

**New homepage sections and supporting logic:**

* Added `FrontendInterviewBanner` component with rich content, mentor highlights, and call-to-action buttons, using data from `frontendInterviewBannerData.ts`. [[1]](diffhunk://#diff-760dda7f060f8ac3499e7b5bd37b53c26a45da1faef7b8c399b786fe303fb690R1-R152) [[2]](diffhunk://#diff-48a7f8d3d20e0cce2e273347d1077333d46303f3ab3b827bf10489ccfd328487R1-R76)
* Added `CohortPricingSection` component displaying multiple pricing plans via `PricingCard`, with plans defined in `cohortData.ts` and strongly typed by `types.ts`. [[1]](diffhunk://#diff-b019ae9ab4da86b89db34c6009f710ce5d4bc21ac3f6a36f1bdf8fc72745af8eR1-R32) [[2]](diffhunk://#diff-fcdd39d4f1e80df6c4d33e85381ad2f56bfed6d177409a046798890b1344bfe6R1-R50) [[3]](diffhunk://#diff-f0e199ea0385a87f9e14ed2dc70d875b1645c93358b58275f1e1b214f7b57dcfR1-R10)
* Exported `CohortPricingSection` from its index for easier imports elsewhere.

**Homepage integration:**

* Imported the new components in `page.tsx` and added (but commented out) their usage in the homepage layout, preparing for future activation. [[1]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR23-R24) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR137-R138)